### PR TITLE
feat(ci): add Dependabot security automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,118 @@
+version: 2
+updates:
+  # Root npm project
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Kubernetes projects
+  - package-ecosystem: "npm"
+    directory: "/Kubernetes/hello-k8s"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/Kubernetes/learning-roadmap/project-01-weather-app/backend"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/Kubernetes/learning-roadmap/project-02-chat-app/backend"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/Kubernetes/learning-roadmap/project-02-chat-app/frontend"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/Kubernetes/next-nest-k8s-app/backend"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/Kubernetes/next-nest-k8s-app/frontend"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  # Terraform projects (npm)
+  - package-ecosystem: "npm"
+    directory: "/Terraform/AWS/Resources/APIGateway/synthetics_test_api"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/Terraform/AWS/Resources/RAG/fe/src"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  # Python/Poetry projects (pip ecosystem for lock file updates)
+  - package-ecosystem: "pip"
+    directory: "/Terraform/AWS/Resources/RAG/be/src/embed_doc"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/Terraform/AWS/Resources/RAG/be/src/answer_user_query"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/Terraform/AWS/Resources/RAG/be/src/vector_database"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,47 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          echo "Enabling auto-merge for patch update: ${{ steps.metadata.outputs.dependency-names }}"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          echo "Enabling auto-merge for minor update: ${{ steps.metadata.outputs.dependency-names }}"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label major updates for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "Major update detected - requires manual review: ${{ steps.metadata.outputs.dependency-names }}"
+          gh pr edit "$PR_URL" --add-label "major-update"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-alert-notify.yml
+++ b/.github/workflows/security-alert-notify.yml
@@ -1,0 +1,140 @@
+name: Security Alert Notification
+
+on:
+  # Daily schedule (JST 10:00 = UTC 01:00)
+  schedule:
+    - cron: "0 1 * * *"
+
+  # Manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-and-notify:
+    runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
+    steps:
+      - name: Check for open security alerts
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get all open Dependabot alerts
+          alerts=$(gh api repos/${{ github.repository }}/dependabot/alerts \
+            --jq '[.[] | select(.state == "open")]' 2>/dev/null || echo "[]")
+
+          alert_count=$(echo "$alerts" | jq 'length')
+          echo "Found $alert_count open security alerts"
+
+          if [ "$alert_count" -gt 0 ]; then
+            echo "has_alerts=true" >> $GITHUB_OUTPUT
+            echo "alert_count=$alert_count" >> $GITHUB_OUTPUT
+            echo "$alerts" > /tmp/alerts.json
+          else
+            echo "has_alerts=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for existing open issue
+        if: steps.check.outputs.has_alerts == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --label "security" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "existing_issue=$existing" >> $GITHUB_OUTPUT
+            echo "Found existing security issue: #$existing"
+          else
+            echo "No existing security issue found"
+          fi
+
+      - name: Create security issue
+        if: steps.check.outputs.has_alerts == 'true' && steps.existing.outputs.existing_issue == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          alerts=$(cat /tmp/alerts.json)
+          current_date=$(date '+%Y-%m-%d %H:%M:%S %Z')
+
+          # Group alerts by ecosystem
+          npm_alerts=$(echo "$alerts" | jq '[.[] | select(.dependency.package.ecosystem == "npm")]')
+          pip_alerts=$(echo "$alerts" | jq '[.[] | select(.dependency.package.ecosystem == "pip")]')
+          actions_alerts=$(echo "$alerts" | jq '[.[] | select(.dependency.package.ecosystem == "github_actions")]')
+
+          # Build issue body
+          {
+            echo "## セキュリティアラート検出"
+            echo ""
+            echo "**検出日時**: ${current_date}"
+            echo "**アラート数**: ${{ steps.check.outputs.alert_count }}件"
+            echo ""
+            echo "---"
+            echo ""
+            echo "## アラート詳細"
+            echo ""
+
+            # npm alerts
+            npm_count=$(echo "$npm_alerts" | jq 'length')
+            if [ "$npm_count" -gt 0 ]; then
+              echo "### npm (${npm_count}件)"
+              echo ""
+              echo "$npm_alerts" | jq -r '.[] | "- **\(.security_advisory.cve_id // "N/A")** - \(.dependency.package.name) (\(.security_advisory.severity))\n  - 影響: \(.security_vulnerability.vulnerable_version_range)\n  - 修正版: \(.security_vulnerability.first_patched_version.identifier // "N/A")\n  - ファイル: \(.dependency.manifest_path)"'
+              echo ""
+            fi
+
+            # pip alerts
+            pip_count=$(echo "$pip_alerts" | jq 'length')
+            if [ "$pip_count" -gt 0 ]; then
+              echo "### pip/Poetry (${pip_count}件)"
+              echo ""
+              echo "$pip_alerts" | jq -r '.[] | "- **\(.security_advisory.cve_id // "N/A")** - \(.dependency.package.name) (\(.security_advisory.severity))\n  - 影響: \(.security_vulnerability.vulnerable_version_range)\n  - 修正版: \(.security_vulnerability.first_patched_version.identifier // "N/A")\n  - ファイル: \(.dependency.manifest_path)"'
+              echo ""
+            fi
+
+            # GitHub Actions alerts
+            actions_count=$(echo "$actions_alerts" | jq 'length')
+            if [ "$actions_count" -gt 0 ]; then
+              echo "### GitHub Actions (${actions_count}件)"
+              echo ""
+              echo "$actions_alerts" | jq -r '.[] | "- **\(.security_advisory.cve_id // "N/A")** - \(.dependency.package.name) (\(.security_advisory.severity))\n  - 影響: \(.security_vulnerability.vulnerable_version_range)\n  - 修正版: \(.security_vulnerability.first_patched_version.identifier // "N/A")\n  - ファイル: \(.dependency.manifest_path)"'
+              echo ""
+            fi
+
+            echo "---"
+            echo ""
+            echo "## 対応方法"
+            echo ""
+            echo "ローカルでClaude Codeを使って修正:"
+            echo ""
+            echo '```bash'
+            echo 'claude "このIssueのセキュリティアラートを修正してPR作成して"'
+            echo '```'
+          } > /tmp/issue_body.md
+
+          gh issue create \
+            --repo ${{ github.repository }} \
+            --title "🔒 セキュリティアラート: ${{ steps.check.outputs.alert_count }}件の脆弱性を検出" \
+            --body-file /tmp/issue_body.md \
+            --label "security"
+
+      - name: Update existing issue
+        if: steps.check.outputs.has_alerts == 'true' && steps.existing.outputs.existing_issue != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current_date=$(date '+%Y-%m-%d %H:%M:%S %Z')
+          gh issue comment ${{ steps.existing.outputs.existing_issue }} \
+            --repo ${{ github.repository }} \
+            --body "⚠️ **定期チェック**: 現在 ${{ steps.check.outputs.alert_count }}件 のセキュリティアラートが未対応です。
+
+          最終確認: ${current_date}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+## Security Fix Workflow
+
+セキュリティIssue（`security`ラベル付き）の修正手順:
+
+### 1. Issueの確認
+```bash
+gh issue view <issue-number>
+```
+
+### 2. 修正作業
+
+#### npm プロジェクト
+対象ディレクトリ:
+- `/Kubernetes/hello-k8s/`
+- `/Kubernetes/learning-roadmap/project-01-weather-app/backend/`
+- `/Kubernetes/learning-roadmap/project-02-chat-app/backend/`
+- `/Kubernetes/learning-roadmap/project-02-chat-app/frontend/`
+- `/Kubernetes/next-nest-k8s-app/backend/`
+- `/Kubernetes/next-nest-k8s-app/frontend/`
+- `/Terraform/AWS/Resources/APIGateway/synthetics_test_api/`
+- `/Terraform/AWS/Resources/RAG/fe/src/`
+
+```bash
+cd <project-dir>
+npm update <package-name>
+# または package.json の overrides に追加
+npm install
+```
+
+#### Python/Poetry プロジェクト
+対象ディレクトリ:
+- `/Terraform/AWS/Resources/RAG/be/src/embed_doc/`
+- `/Terraform/AWS/Resources/RAG/be/src/answer_user_query/`
+- `/Terraform/AWS/Resources/RAG/be/src/vector_database/`
+
+```bash
+cd <project-dir>
+# pyproject.toml を編集して依存関係を更新
+poetry lock
+# requirements.txt がある場合は再生成
+poetry export -f requirements.txt --output requirements.txt --without-hashes
+```
+
+#### GitHub Actions
+対象: `.github/workflows/*.yml`
+
+```bash
+# アクションバージョンを更新（例: actions/checkout@v3 → @v4）
+```
+
+### 3. PR作成
+```bash
+git checkout -b fix-sec/security-fix-$(date +%Y%m%d)
+git add -A
+git commit -m "fix(security): <CVE-ID> の脆弱性を修正"
+git push origin HEAD
+gh pr create --title "fix(security): セキュリティ脆弱性の修正" --body "Fixes #<issue-number>"
+```
+
+### 簡易コマンド
+```bash
+claude "セキュリティIssue #<番号>を修正してPR作成して"
+```


### PR DESCRIPTION
## Summary

Dependabotセキュリティアラートの自動対応システムを追加します。

- **dependabot.yml**: npm/pip/GitHub Actionsの依存関係を毎日監視
- **security-alert-notify.yml**: アラート検知時にIssueを自動作成
- **dependabot-auto-merge.yml**: patch/minorアップデートの自動マージ
- **CLAUDE.md**: セキュリティ修正手順のドキュメント

## Test plan (マージ後)

- [ ] GitHub Settings → Code security でDependabotが有効化されたことを確認
- [ ] 翌日以降、`security-alert-notify.yml`を手動トリガーでテスト実行
- [ ] Dependabot PRが作成されたら自動マージの動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)