### PR TITLE
fix(ci): use PAT for Dependabot alerts API access

### DIFF
--- a/.github/workflows/security-alert-notify.yml
+++ b/.github/workflows/security-alert-notify.yml
@@ -33,9 +33,9 @@ jobs:
           api_error=$(cat "$error_output")
           rm -f "$error_output"
 
-          # Log API error if any
+          # Log API error if any (plain output to avoid workflow command injection)
           if [ -n "$api_error" ]; then
-            echo "::warning::API stderr: $api_error"
+            echo "API stderr: $api_error"
           fi
 
           # Check if response is empty, error, or valid
@@ -52,6 +52,12 @@ jobs:
             echo "::error::Failed to parse Dependabot alerts API response"
             exit 1
           }
+
+          # Ensure the merged result is an array before counting alerts
+          if ! echo "$alerts" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "::error::Unexpected Dependabot alerts API response format (expected JSON array)"
+            exit 1
+          fi
 
           alert_count=$(echo "$alerts" | jq -r 'length')
           echo "Found $alert_count open security alerts"


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN`ではDependabot alerts APIにアクセスできず、常に0件として処理されていた問題を修正
- Fine-grained PAT (`PAT_SECURITY` secret) を使用するように変更
- エラー時にワークフローを失敗させるように改善（silent successの防止）

## Changes
- `GH_TOKEN`を`secrets.PAT_SECURITY`に変更（alerts取得ステップのみ）
- stderrを分離してjqパース失敗を防止
- `?state=open`クエリパラメータでサーバー側フィルタ
- `jq -s 'add // []'`でpaginate複数配列を統合する方式に簡略化
- API失敗時に`exit 1`で明示的にワークフローを失敗させる

## Test plan
- [ ] `PAT_SECURITY` secretが設定済みであることを確認
- [ ] `gh workflow run security-alert-notify.yml` で手動実行
- [ ] ワークフローがsuccessで完了し、securityラベル付きIssueが作成されることを確認
- [ ] Issueにopen状態のアラート2件が記載されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)