### PR TITLE
fix(ci): requirements.txt から python_full_version マーカーを除去

### DIFF
--- a/Terraform/AWS/Resources/RAG/be/src/embed_doc/requirements.txt
+++ b/Terraform/AWS/Resources/RAG/be/src/embed_doc/requirements.txt
@@ -1,58 +1,58 @@
-aiohappyeyeballs==2.6.1 ; python_full_version == "3.10.5"
-aiohttp==3.13.3 ; python_full_version == "3.10.5"
-aiosignal==1.4.0 ; python_full_version == "3.10.5"
-annotated-types==0.7.0 ; python_full_version == "3.10.5"
-anyio==4.9.0 ; python_full_version == "3.10.5"
-async-timeout==4.0.3 ; python_full_version == "3.10.5"
-attrs==25.3.0 ; python_full_version == "3.10.5"
-boto3==1.39.12 ; python_full_version == "3.10.5"
-botocore==1.39.12 ; python_full_version == "3.10.5"
-certifi==2025.7.14 ; python_full_version == "3.10.5"
-cffi==1.17.1 ; python_full_version == "3.10.5" and platform_python_implementation == "PyPy"
-charset-normalizer==3.4.2 ; python_full_version == "3.10.5"
-dataclasses-json==0.6.7 ; python_full_version == "3.10.5"
-exceptiongroup==1.3.0 ; python_full_version == "3.10.5"
-frozenlist==1.7.0 ; python_full_version == "3.10.5"
-greenlet==3.2.3 ; python_full_version == "3.10.5" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
-h11==0.16.0 ; python_full_version == "3.10.5"
-httpcore==1.0.9 ; python_full_version == "3.10.5"
-httpx-sse==0.4.1 ; python_full_version == "3.10.5"
-httpx==0.28.1 ; python_full_version == "3.10.5"
-idna==3.10 ; python_full_version == "3.10.5"
-jmespath==1.0.1 ; python_full_version == "3.10.5"
-jsonpatch==1.33 ; python_full_version == "3.10.5"
-jsonpointer==3.0.0 ; python_full_version == "3.10.5"
-langchain-classic==1.0.1 ; python_full_version == "3.10.5"
-langchain-community==0.4.1 ; python_full_version == "3.10.5"
-langchain-core==1.2.11 ; python_full_version == "3.10.5"
-langchain-text-splitters==1.1.0 ; python_full_version == "3.10.5"
-langsmith==0.4.8 ; python_full_version == "3.10.5"
-marshmallow==3.26.2 ; python_full_version == "3.10.5"
-multidict==6.6.3 ; python_full_version == "3.10.5"
-mypy-extensions==1.1.0 ; python_full_version == "3.10.5"
-numpy==2.2.6 ; python_full_version == "3.10.5"
-orjson==3.11.6 ; python_full_version == "3.10.5"
-packaging==25.0 ; python_full_version == "3.10.5"
-propcache==0.3.2 ; python_full_version == "3.10.5"
-pycparser==2.22 ; python_full_version == "3.10.5" and platform_python_implementation == "PyPy"
-pydantic-core==2.33.2 ; python_full_version == "3.10.5"
-pydantic-settings==2.10.1 ; python_full_version == "3.10.5"
-pydantic==2.11.7 ; python_full_version == "3.10.5"
-pypdf==6.7.5 ; python_full_version == "3.10.5"
-python-dateutil==2.9.0.post0 ; python_full_version == "3.10.5"
-python-dotenv==1.1.1 ; python_full_version == "3.10.5"
-pyyaml==6.0.2 ; python_full_version == "3.10.5"
-requests-toolbelt==1.0.0 ; python_full_version == "3.10.5"
-requests==2.32.5 ; python_full_version == "3.10.5"
-s3transfer==0.13.1 ; python_full_version == "3.10.5"
-six==1.17.0 ; python_full_version == "3.10.5"
-sniffio==1.3.1 ; python_full_version == "3.10.5"
-sqlalchemy==2.0.41 ; python_full_version == "3.10.5"
-tenacity==9.1.2 ; python_full_version == "3.10.5"
-typing-extensions==4.14.1 ; python_full_version == "3.10.5"
-typing-inspect==0.9.0 ; python_full_version == "3.10.5"
-typing-inspection==0.4.1 ; python_full_version == "3.10.5"
-urllib3==2.6.3 ; python_full_version == "3.10.5"
-uuid-utils==0.14.0 ; python_full_version == "3.10.5"
-yarl==1.20.1 ; python_full_version == "3.10.5"
-zstandard==0.23.0 ; python_full_version == "3.10.5"
+aiohappyeyeballs==2.6.1
+aiohttp==3.13.3
+aiosignal==1.4.0
+annotated-types==0.7.0
+anyio==4.9.0
+async-timeout==4.0.3
+attrs==25.3.0
+boto3==1.39.12
+botocore==1.39.12
+certifi==2025.7.14
+cffi==1.17.1 ; platform_python_implementation == "PyPy"
+charset-normalizer==3.4.2
+dataclasses-json==0.6.7
+exceptiongroup==1.3.0
+frozenlist==1.7.0
+greenlet==3.2.3 ; platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32"
+h11==0.16.0
+httpcore==1.0.9
+httpx-sse==0.4.1
+httpx==0.28.1
+idna==3.10
+jmespath==1.0.1
+jsonpatch==1.33
+jsonpointer==3.0.0
+langchain-classic==1.0.1
+langchain-community==0.4.1
+langchain-core==1.2.11
+langchain-text-splitters==1.1.0
+langsmith==0.4.8
+marshmallow==3.26.2
+multidict==6.6.3
+mypy-extensions==1.1.0
+numpy==2.2.6
+orjson==3.11.6
+packaging==25.0
+propcache==0.3.2
+pycparser==2.22 ; platform_python_implementation == "PyPy"
+pydantic-core==2.33.2
+pydantic-settings==2.10.1
+pydantic==2.11.7
+pypdf==6.7.5
+python-dateutil==2.9.0.post0
+python-dotenv==1.1.1
+pyyaml==6.0.2
+requests-toolbelt==1.0.0
+requests==2.32.5
+s3transfer==0.13.1
+six==1.17.0
+sniffio==1.3.1
+sqlalchemy==2.0.41
+tenacity==9.1.2
+typing-extensions==4.14.1
+typing-inspect==0.9.0
+typing-inspection==0.4.1
+urllib3==2.6.3
+uuid-utils==0.14.0
+yarl==1.20.1
+zstandard==0.23.0


### PR DESCRIPTION
## Summary
- `embed_doc/requirements.txt` の全パッケージに付与されていた `python_full_version == "3.10.5"` マーカーを除去
- GitHub Actions の `setup-python@v4` が Python 3.10.19 をインストールするようになったため、マーカー不一致で全パッケージが Ignore され、Lambda レイヤーが空になり `terraform plan` が失敗していた
- `cffi`/`pycparser` の `platform_python_implementation` マーカーと `greenlet` の `platform_machine` マーカーはプラットフォーム依存のため維持

## Test plan
- [x] ローカルで `pip install --platform manylinux2014_x86_64 --implementation cp --python-version 3.10 --only-binary=:all: -r requirements.txt` を実行し、全58パッケージが正常にインストールされることを確認済み
- [ ] CI の TerraformCI ワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)