### PR TITLE
fix(ci): requirements.txtのenvironment markers構文を修正

### DIFF
--- a/Terraform/AWS/Resources/RAG/be/src/embed_doc/requirements.txt
+++ b/Terraform/AWS/Resources/RAG/be/src/embed_doc/requirements.txt
@@ -8,12 +8,12 @@ attrs==25.3.0
 boto3==1.39.12
 botocore==1.39.12
 certifi==2025.7.14
-cffi==1.17.1 and platform_python_implementation == "PyPy"
+cffi==1.17.1; platform_python_implementation == "PyPy"
 charset-normalizer==3.4.2
 dataclasses-json==0.6.7
 exceptiongroup==1.3.0
 frozenlist==1.7.0
-greenlet==3.2.3 and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
+greenlet==3.2.3; platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32"
 h11==0.16.0
 httpcore==1.0.9
 httpx-sse==0.4.1
@@ -34,7 +34,7 @@ numpy==2.2.6
 orjson==3.11.6
 packaging==25.0
 propcache==0.3.2
-pycparser==2.22 and platform_python_implementation == "PyPy"
+pycparser==2.22; platform_python_implementation == "PyPy"
 pydantic-core==2.33.2
 pydantic-settings==2.10.1
 pydantic==2.11.7


### PR DESCRIPTION
## Summary
- `embed_doc/requirements.txt`のenvironment markers構文を`and`から`;`（セミコロン）に修正（PEP 508準拠）
- cffi, greenlet, pycparserの3箇所を修正
- TerraformCIのpip installステップで発生していたパースエラーを解消

## Test plan
- [ ] TerraformCIワークフローが正常に完了することを確認
- [ ] `pip install --dry-run`で構文エラーが出ないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)