### PR TITLE
fix(security): CVE-2026-32630 file-type の脆弱性を修正

### DIFF
--- a/Kubernetes/learning-roadmap/project-02-chat-app/backend/package.json
+++ b/Kubernetes/learning-roadmap/project-02-chat-app/backend/package.json
@@ -69,7 +69,7 @@
     "minimatch": ">=3.1.3 <9.0.0 || >=9.0.7 <10.0.0 || >=10.2.3",
     "serialize-javascript": ">=7.0.3",
     "multer": ">=2.1.1",
-    "file-type": ">=21.3.1 <22"
+    "file-type": ">=21.3.2 <22"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/Kubernetes/next-nest-k8s-app/backend/package-lock.json
+++ b/Kubernetes/next-nest-k8s-app/backend/package-lock.json
@@ -5822,9 +5822,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.1.tgz",
-      "integrity": "sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",

--- a/Kubernetes/next-nest-k8s-app/backend/package.json
+++ b/Kubernetes/next-nest-k8s-app/backend/package.json
@@ -58,7 +58,7 @@
   "overrides": {
     "qs": "^6.14.2",
     "tar": "^7.5.11",
-    "file-type": ">=21.3.1 <22",
+    "file-type": ">=21.3.2 <22",
     "webpack": "^5.104.1",
     "minimatch": ">=10.2.1",
     "serialize-javascript": ">=7.0.3",


### PR DESCRIPTION
## Summary
- CVE-2026-32630 に対応するため、`file-type` パッケージの overrides を `>=21.3.2 <22` に更新
- 影響を受けた2つのプロジェクト:
  - `Kubernetes/learning-roadmap/project-02-chat-app/backend`
  - `Kubernetes/next-nest-k8s-app/backend`

## Test plan
- [x] `npm ls file-type` で 21.3.2 に更新されていることを確認
- [x] `npm audit` で CVE-2026-32630 が解消されていることを確認
- [x] `git diff` で意図しない変更がないことを確認

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)