### PR TITLE
fix: retro スキルのフロントマター属性を修正

### DIFF
--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -2,7 +2,7 @@
 name: retro
 description: PR のレビューコメントを振り返り、スキルやルールの改善案を提案する
 disable-model-invocation: true
-args: "[PR番号]"
+argument-hint: "[PR番号]"
 ---
 
 PR のレビューコメントを振り返り、作業プロセスやスキル・ルールの改善案を検討します。


### PR DESCRIPTION
## Summary
- retro スキルの未サポート属性 `args` を正しい `argument-hint` に変更
- スキルの動作への影響なし（表示用メタデータのみの変更）

## Test plan
- [ ] `/retro` コマンドが引数なしで正常に動作すること
- [ ] `/retro [PR番号]` で引数付き実行が正常に動作すること
- [ ] フロントマターの警告メッセージが表示されなくなること

🤖 Generated with [Claude Code](https://claude.com/claude-code)