### PR TITLE
chore: セキュリティアラート通知の改善

### DIFF
--- a/.github/workflows/security-alert-notify.yml
+++ b/.github/workflows/security-alert-notify.yml
@@ -225,7 +225,8 @@ jobs:
           # Extract fingerprint from the last bot comment's HTML marker
           last_fingerprint=$(gh api "repos/${{ github.repository }}/issues/${issue_number}/comments" \
             --paginate \
-            --jq '[.[] | select(.user.login == "github-actions[bot]") | .body] | last // ""' \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | .body' \
+            | tail -n 1 \
             | grep -oP '<!-- fingerprint:\K[a-f0-9]+' || echo "")
 
           if [ "$last_fingerprint" = "$current_fingerprint" ]; then


### PR DESCRIPTION
## Summary
- 修正版がないアラート (`first_patched_version == null`) を通知対象から除外し、対応不可能なアラートによるノイズを防止
- 前回コメントのアラート数と比較し、変化がない場合はコメントをスキップして重複通知を防止
- Issue body / コメントに「修正版なし」の件数を併記し、全体像を把握可能に

## 変更の背景
Pygments (CVE-2026-4539) のように修正版が未リリースのアラートが存在すると、毎日同じ内容のコメントが Issue に追加され続ける問題があった。

## Test plan
- [ ] `workflow_dispatch` で手動実行し、修正版なしのアラートが除外されることを確認
- [ ] アラート数が変化しない場合にコメントがスキップされることを確認
- [ ] 新しいアラートが追加された場合にコメントが正しく投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)