### PR TITLE
chore: security-fix スキルの改善（retro 振り返り）

### DIFF
--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -18,6 +18,7 @@ security ラベル付きのオープン Issue を修正して PR を作成して
    - **npm**:
      - 直接依存の場合: package.json のバージョンを直接更新
      - 間接依存の場合: package.json の overrides に修正バージョンを追加
+     - overrides のキーは常にメジャーバージョンスコープで指定する（例: `"picomatch@2": "~2.3.2"`）。スコープなしの `"picomatch"` は将来別メジャーバージョンが追加された場合に意図しない影響を与えるため使わない
      - overrides のバージョンはメジャーバージョンアップを防ぐため、固定バージョン（例: `"4.2.6"`）またはパッチ範囲（例: `"~4.2.6"`）で指定する。`>=` のようなオープンレンジは使わない
      - 修正手順（段階的に実施すること）:
        1. 既存の `package-lock.json` を保持したまま `npm install` を実行
@@ -40,4 +41,6 @@ security ラベル付きのオープン Issue を修正して PR を作成して
 
 - ブランチ: `fix-sec/security-fix-YYYYMMDD`（同日に複数の場合は末尾に連番）
 - コミットメッセージ: `fix(security): <CVE-ID> の脆弱性を修正`
-- PR body に `Fixes #<issue-number>` を含める
+- PR body に Issue へのリンクを含める
+  - PR が Issue の全アラートを修正する場合: `Fixes #<issue-number>`（マージ時に Issue が自動クローズされる）
+  - 一部のアラートのみ修正する場合: `Related #<issue-number>`（Issue はオープンのまま残す）


### PR DESCRIPTION
## Summary
PR #206, #207, #208 のレビューコメントを振り返り、security-fix スキルに以下の改善を追加:

- npm overrides のキーは常にメジャーバージョンスコープ（例: `"picomatch@2": "~2.3.2"`）で指定するルールを追加
- PR body の `Fixes` vs `Related` を、Issue の全アラートを修正するかどうかで使い分けるルールを追加

## 背景
- PR #207 で `"picomatch"` と `"picomatch@2"` が混在し、レビューで指摘を受けた
- PR #206, #207 で `Fixes #202` を使用したが、Issue #202 には未修正の Pygments アラートも含まれており、マージ時の誤クローズリスクを指摘された

## Test plan
- [ ] スキルファイルの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)