### PR TITLE
chore: security-fix スキルの生成ファイル検証手順を具体化

### DIFF
--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -26,15 +26,15 @@ security ラベル付きのオープン Issue を修正して PR を作成して
        3. 古いバージョンが残っている場合**のみ** `package-lock.json` を削除して `npm install` で再生成
        4. `git diff -- package-lock.json` で差分が対象パッケージの更新のみであることを確認する。npm バージョン差等により無関係な変更（`"dev": true` の追加等）が混入した場合は、以下のフォールバック手順で churn を最小化する:
           1. `git checkout main -- package-lock.json` でロックファイルを復元
-          2. 対象パッケージのエントリ（version, resolved, integrity）を手動で更新
+          2. 対象パッケージの全エントリ（version, resolved, integrity, dependencies, funding 等のメタデータを含む）を手動で更新する。同一パッケージが複数箇所に出現する場合はすべて更新すること
           3. `npm ci` でロックファイルの整合性を検証
    - **Python/Poetry**: pyproject.toml を更新 → `poetry lock` → `poetry export -f requirements.txt --without-hashes` で requirements.txt を生成。`requires-python` が特定バージョン固定（例: `"3.10.5"`）の場合、出力に `python_full_version == "3.10.5"` マーカーが全行に付与されるため、以下の後処理でマーカーを除去してからファイルに書き出す:
      ```bash
      poetry export -f requirements.txt --without-hashes | \
-       sed 's/ ; python_full_version == "[^"]*" and /; /g' | \
-       sed 's/ ; python_full_version == "[^"]*"//g' > requirements.txt
+       sed 's/[[:space:]]*;[[:space:]]*python_full_version == "[^"]*" and /; /g' | \
+       sed 's/[[:space:]]*;[[:space:]]*python_full_version == "[^"]*"//g' > requirements.txt
      ```
-     後処理後、`diff <(git show main:<path>/requirements.txt) <path>/requirements.txt` で main と比較し、意図した変更（バージョン更新）のみであることを確認する
+     後処理後、`git diff main -- <path>/requirements.txt` で main と比較し、意図した変更（バージョン更新）のみであることを確認する
    - **GitHub Actions**: アクションバージョンを更新
 7. 修正の検証:
    - `npm ls <package>` でバージョンが更新されていることを確認


### PR DESCRIPTION
## Summary
- npm: `package-lock.json` の差分検証手順と、churn 発生時の手動編集フォールバック手順を追加
- Python/Poetry: `poetry export` 後の `python_full_version` マーカー除去手順と main との diff 確認を追加

PR #216 のレトロスペクティブに基づく改善。

## 背景
PR #216 で以下のレビュー指摘を受けた:
1. `requirements.txt` に `python_full_version == "3.10.5"` マーカーが混入
2. `package-lock.json` に `dev: true` 等の無関係な変更が 91箇所混入

既存スキルの step 7 に検証ルールはあったが具体性が不足していたため、step 6 に具体的な手順を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)