### PR TITLE
fix(security): CVE-2026-34043 serialize-javascript の脆弱性を修正

### DIFF
--- a/Kubernetes/learning-roadmap/project-02-chat-app/backend/package-lock.json
+++ b/Kubernetes/learning-roadmap/project-02-chat-app/backend/package-lock.json
@@ -8900,9 +8900,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/Kubernetes/learning-roadmap/project-02-chat-app/backend/package.json
+++ b/Kubernetes/learning-roadmap/project-02-chat-app/backend/package.json
@@ -67,7 +67,7 @@
     "validator": "^13.15.22",
     "qs": "^6.14.2",
     "minimatch": ">=3.1.3 <9.0.0 || >=9.0.7 <10.0.0 || >=10.2.3",
-    "serialize-javascript": ">=7.0.3",
+    "serialize-javascript": "~7.0.5",
     "multer": ">=2.1.1",
     "file-type": ">=21.3.2 <22",
     "flatted": "~3.4.2",

--- a/Kubernetes/next-nest-k8s-app/backend/package-lock.json
+++ b/Kubernetes/next-nest-k8s-app/backend/package-lock.json
@@ -9810,9 +9810,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/Kubernetes/next-nest-k8s-app/backend/package.json
+++ b/Kubernetes/next-nest-k8s-app/backend/package.json
@@ -61,7 +61,7 @@
     "file-type": ">=21.3.2 <22",
     "webpack": "^5.104.1",
     "minimatch": ">=10.2.1",
-    "serialize-javascript": ">=7.0.3",
+    "serialize-javascript": "~7.0.5",
     "multer": ">=2.1.1",
     "@tootallnate/once": ">=3.0.1",
     "flatted": "~3.4.2",


### PR DESCRIPTION
## Summary
- serialize-javascript を 7.0.3 → 7.0.5 に更新し、CVE-2026-34043 を解消
- 対象: `Kubernetes/next-nest-k8s-app/backend`, `Kubernetes/learning-roadmap/project-02-chat-app/backend`
- overrides のバージョン指定をオープンレンジ (`>=7.0.3`) からパッチ範囲 (`~7.0.5`) に変更

## Test plan
- [x] `npm ls serialize-javascript` で 7.0.5 に更新されていることを確認
- [x] `npm audit` で CVE-2026-34043 が解消されていることを確認
- [x] `npm ci` でロックファイルの整合性を検証
- [x] `git diff` で意図しない変更がないことを確認

Related #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)