### PR TITLE
fix(security): CVE-2025-71176 の脆弱性を修正

### DIFF
--- a/Terraform/AWS/Resources/RAG/be/src/answer_user_query/poetry.lock
+++ b/Terraform/AWS/Resources/RAG/be/src/answer_user_query/poetry.lock
@@ -305,21 +305,21 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
-    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -470,4 +470,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "3.10.5"
-content-hash = "75a1576789d7b1576ac466518a8cacd856704f65b4431c7d49f42cb45f213023"
+content-hash = "6513950ea263d92b24f8a1aa08d4658914b676f689dae5b920c8a6db2962ef8c"

--- a/Terraform/AWS/Resources/RAG/be/src/answer_user_query/pyproject.toml
+++ b/Terraform/AWS/Resources/RAG/be/src/answer_user_query/pyproject.toml
@@ -20,5 +20,5 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.4.1"
+pytest = "^9.0.3"
 

--- a/Terraform/AWS/Resources/RAG/be/src/embed_doc/poetry.lock
+++ b/Terraform/AWS/Resources/RAG/be/src/embed_doc/poetry.lock
@@ -1619,21 +1619,21 @@ image = ["Pillow (>=8.0.0)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
-    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -2296,4 +2296,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "3.10.5"
-content-hash = "427f2250ef2a1f2cccd89f5a83c78825936a48945439ce7ea40bb06c3788e596"
+content-hash = "3aa87d1466508c0de6832d83059d42f6384dced7bf9d59e313277bc26a859a16"

--- a/Terraform/AWS/Resources/RAG/be/src/embed_doc/pyproject.toml
+++ b/Terraform/AWS/Resources/RAG/be/src/embed_doc/pyproject.toml
@@ -30,5 +30,5 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.4.1"
+pytest = "^9.0.3"
 

--- a/Terraform/AWS/Resources/RAG/be/src/vector_database/poetry.lock
+++ b/Terraform/AWS/Resources/RAG/be/src/vector_database/poetry.lock
@@ -305,21 +305,21 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
-    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -470,4 +470,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "3.10.5"
-content-hash = "e135b44824b1fe2af84863b9d35b210d72d33bdb2b823a626fd643babd74860a"
+content-hash = "04e5ab275ebeb0073af64bb3220f09df22a03aae2bfa467d28c07f2b34d435fd"

--- a/Terraform/AWS/Resources/RAG/be/src/vector_database/pyproject.toml
+++ b/Terraform/AWS/Resources/RAG/be/src/vector_database/pyproject.toml
@@ -19,6 +19,6 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.4.1"
+pytest = "^9.0.3"
 boto3 = "^1.39.14"
 


### PR DESCRIPTION
## Summary

pytest を 8.4.1 から 9.0.3 にアップグレードし、CVE-2025-71176 を解消しました（dev 依存）。

## 対応する CVE / Dependabot アラート

- CVE-2025-71176 — pytest (< 9.0.3) → 9.0.3
  - Dependabot alert #458: `Terraform/AWS/Resources/RAG/be/src/answer_user_query/poetry.lock`
  - Dependabot alert #459: `Terraform/AWS/Resources/RAG/be/src/vector_database/poetry.lock`
  - Dependabot alert #460: `Terraform/AWS/Resources/RAG/be/src/embed_doc/poetry.lock`

## 変更内容

- 3プロジェクトの `pyproject.toml` で `pytest = "^8.4.1"` → `"^9.0.3"` に更新
- `poetry lock` で `poetry.lock` を再生成（pytest は dev 依存のため `requirements.txt` に変更なし）

## 事前確認

- pytest 9.0.3 は PyPI で yanked されておらず、2026-04-07 公開
- 直近のサプライチェーン攻撃報告（LiteLLM / Telnyx / Trivy / KICS 等）に pytest の名前はなし

Fixes #239

## Test plan

- [ ] CI が通過すること
- [ ] マージ後に Dependabot アラート #458, #459, #460 がクローズされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)