### PR TITLE
chore(security-fix): Poetry 修正時の下限バージョン指針を追加

### DIFF
--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -33,7 +33,7 @@ security ラベル付きのオープン Issue を修正して PR を作成して
           2. 対象パッケージの全エントリ（version, resolved, integrity, dependencies, funding 等のメタデータを含む）を手動で更新する。同一パッケージが複数箇所に出現する場合はすべて更新すること
           3. `npm ci` でロックファイルの整合性を検証
    - **Python/Poetry**: pyproject.toml を更新 → `poetry lock` → `poetry export -f requirements.txt --without-hashes` で requirements.txt を生成。
-     - pyproject.toml の下限バージョンはまず Dependabot の `first_patched_version` 以上に設定する。`poetry lock` 実行後、解決された実バージョンが下限より新しい場合は、下限を実バージョンに揃えて再度 `poetry lock` を実行する（pyproject.toml と lock ファイルの一貫性を保つため）。解決された実バージョンと下限が一致していれば再 lock は不要
+     - pyproject.toml の下限バージョンはまず Dependabot の `first_patched_version` 以上に設定する。`poetry lock` 実行後、`poetry show --lock <package>` または `poetry.lock` の該当エントリで解決された実バージョンを確認する。実バージョンが下限より新しい場合は、下限を実バージョンに揃えて再度 `poetry lock` を実行する（Poetry は既に lock 済みのパッケージを再解決しないため、2 回目は content-hash のみ更新され他の依存は影響を受けない）。実バージョンと下限が一致していれば再 lock は不要
      - `requires-python` が特定バージョン固定（例: `"3.10.5"`）の場合、出力に `python_full_version == "3.10.5"` マーカーが全行に付与されるため、以下の後処理でマーカーを除去してからファイルに書き出す:
      ```bash
      poetry export -f requirements.txt --without-hashes | \

--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -32,7 +32,9 @@ security ラベル付きのオープン Issue を修正して PR を作成して
           1. `git checkout main -- package-lock.json` でロックファイルを復元
           2. 対象パッケージの全エントリ（version, resolved, integrity, dependencies, funding 等のメタデータを含む）を手動で更新する。同一パッケージが複数箇所に出現する場合はすべて更新すること
           3. `npm ci` でロックファイルの整合性を検証
-   - **Python/Poetry**: pyproject.toml を更新 → `poetry lock` → `poetry export -f requirements.txt --without-hashes` で requirements.txt を生成。`requires-python` が特定バージョン固定（例: `"3.10.5"`）の場合、出力に `python_full_version == "3.10.5"` マーカーが全行に付与されるため、以下の後処理でマーカーを除去してからファイルに書き出す:
+   - **Python/Poetry**: pyproject.toml を更新 → `poetry lock` → `poetry export -f requirements.txt --without-hashes` で requirements.txt を生成。
+     - pyproject.toml の下限バージョンはまず Dependabot の `first_patched_version` 以上に設定する。`poetry lock` 実行後、解決された実バージョンが下限より新しい場合は、下限を実バージョンに揃えて再度 `poetry lock` を実行する（pyproject.toml と lock ファイルの一貫性を保つため）。解決された実バージョンと下限が一致していれば再 lock は不要
+     - `requires-python` が特定バージョン固定（例: `"3.10.5"`）の場合、出力に `python_full_version == "3.10.5"` マーカーが全行に付与されるため、以下の後処理でマーカーを除去してからファイルに書き出す:
      ```bash
      poetry export -f requirements.txt --without-hashes | \
        sed 's/[[:space:]]*;[[:space:]]*python_full_version == "[^"]*" and /; /g' | \


### PR DESCRIPTION
## Summary

PR #245 のレビュー指摘（Copilot）で挙がった「pyproject.toml の下限（`>=6.10.1`）と lock の実バージョン（`6.10.2`）のドリフト」への再発防止ルールを skill に追加する。

## 背景

- PR #245 では Dependabot の `first_patched_version` をそのまま `pyproject.toml` の下限に用いた結果、`poetry lock` で解決された実バージョンとドリフトが発生。
- これはセキュリティ上の問題ではない（`first_patched_version` 以上は脆弱版を含まない）が、pyproject.toml と lock ファイルの一貫性を損ねレビュー指摘を招いた。

## 変更内容

`.claude/skills/security-fix/SKILL.md` の Python/Poetry セクションに以下を追加:

> pyproject.toml の下限バージョンはまず Dependabot の `first_patched_version` 以上に設定する。`poetry lock` 実行後、解決された実バージョンが下限より新しい場合は、下限を実バージョンに揃えて再度 `poetry lock` を実行する（pyproject.toml と lock ファイルの一貫性を保つため）。解決された実バージョンと下限が一致していれば再 lock は不要

## 設計判断

- 2 pass lock は「ドリフトが発生した場合のみ」に限定し、不要なケースではオーバーヘッドを発生させない。
- `first_patched_version` を下限にする選択肢も残す（セキュリティ的には十分なため）。最終状態だけ lock と揃える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)