### PR TITLE
chore(security-fix): Fixes/Related 判定ルールを明確化

### DIFF
--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -59,7 +59,7 @@ security ラベル付きのオープン Issue を修正して PR を作成して
 - コミットメッセージ: `fix(security): <CVE-ID> の脆弱性を修正`
 - PR body には以下を含める（Issue 本文の記載有無に関わらず PR body は自己完結させる）:
   - 本 PR で対応する CVE / Dependabot アラート ID の明示リスト
-  - Issue へのリンク（判定基準は「PR マージ後に Dependabot の修正可能な open アラート（`state=="open"` かつ `.security_vulnerability.first_patched_version != null`）が 0 件になるか」の 1 点のみ。security-alert-notify ワークフローが Issue 化対象としているのが修正可能アラートのみのため基準を揃える。Issue 本文の記載件数は判定に使わない）:
+  - Issue へのリンク（判定基準は「PR マージ後に Dependabot の修正可能な open アラート（jq 条件: `.state=="open"` かつ `.security_vulnerability.first_patched_version != null`）が 0 件になるか」の 1 点のみ。security-alert-notify ワークフローが Issue 化対象としているのが修正可能アラートのみのため基準を揃える。Issue 本文の記載件数は判定に使わない）:
     - マージ後に修正可能な open アラートが 0 件になる場合: `Fixes #<issue-number>`（マージ時に Issue が自動クローズされる）
     - マージ後も修正可能な open アラートが残る場合: `Related #<issue-number>`（Issue はオープンのまま残す）
-    - いずれの場合も、Issue 本文・コメント未記載の Dependabot アラートを追加で修正している場合は、該当アラートが Issue 未記載である旨を PR body に明記する
+    - いずれの場合も、Issue 本文（security-alert-notify が初回作成時に出力するアラート一覧）に未記載の Dependabot アラートを追加で修正している場合は、該当アラートが Issue 未記載である旨を PR body に明記する（定期チェックコメントは件数のみでアラート詳細を持たないため判定材料にはしない）

--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -59,7 +59,7 @@ security ラベル付きのオープン Issue を修正して PR を作成して
 - コミットメッセージ: `fix(security): <CVE-ID> の脆弱性を修正`
 - PR body には以下を含める（Issue 本文の記載有無に関わらず PR body は自己完結させる）:
   - 本 PR で対応する CVE / Dependabot アラート ID の明示リスト
-  - Issue へのリンク:
-    - PR が Issue の全アラートを修正する場合: `Fixes #<issue-number>`（マージ時に Issue が自動クローズされる）
-    - 一部のアラートのみ修正する場合: `Related #<issue-number>`（Issue はオープンのまま残す）
-    - Issue 本文に記載がないが Dependabot で検出されたアラートを修正する場合: `Related #<issue-number>` とした上で、該当アラートが Issue 本文未記載である旨を PR body に明記する
+  - Issue へのリンク（判定基準は「PR マージ後に Dependabot の open アラートが 0 件になるか」の 1 点のみ。Issue 本文の記載件数は判定に使わない）:
+    - マージ後に Dependabot の open アラートが 0 件になる場合: `Fixes #<issue-number>`（マージ時に Issue が自動クローズされる）
+    - マージ後も Dependabot の open アラートが残る場合: `Related #<issue-number>`（Issue はオープンのまま残す）
+    - いずれの場合も、Issue 本文未記載の Dependabot アラートを追加で修正している場合は、該当アラートが Issue 本文未記載である旨を PR body に明記する

--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -59,7 +59,7 @@ security ラベル付きのオープン Issue を修正して PR を作成して
 - コミットメッセージ: `fix(security): <CVE-ID> の脆弱性を修正`
 - PR body には以下を含める（Issue 本文の記載有無に関わらず PR body は自己完結させる）:
   - 本 PR で対応する CVE / Dependabot アラート ID の明示リスト
-  - Issue へのリンク（判定基準は「PR マージ後に Dependabot の修正可能な open アラート（`first_patched_version != null`）が 0 件になるか」の 1 点のみ。security-alert-notify ワークフローが Issue 化対象としているのが修正可能アラートのみのため基準を揃える。Issue 本文の記載件数は判定に使わない）:
+  - Issue へのリンク（判定基準は「PR マージ後に Dependabot の修正可能な open アラート（`state=="open"` かつ `.security_vulnerability.first_patched_version != null`）が 0 件になるか」の 1 点のみ。security-alert-notify ワークフローが Issue 化対象としているのが修正可能アラートのみのため基準を揃える。Issue 本文の記載件数は判定に使わない）:
     - マージ後に修正可能な open アラートが 0 件になる場合: `Fixes #<issue-number>`（マージ時に Issue が自動クローズされる）
     - マージ後も修正可能な open アラートが残る場合: `Related #<issue-number>`（Issue はオープンのまま残す）
     - いずれの場合も、Issue 本文・コメント未記載の Dependabot アラートを追加で修正している場合は、該当アラートが Issue 未記載である旨を PR body に明記する

--- a/.claude/skills/security-fix/SKILL.md
+++ b/.claude/skills/security-fix/SKILL.md
@@ -59,7 +59,7 @@ security ラベル付きのオープン Issue を修正して PR を作成して
 - コミットメッセージ: `fix(security): <CVE-ID> の脆弱性を修正`
 - PR body には以下を含める（Issue 本文の記載有無に関わらず PR body は自己完結させる）:
   - 本 PR で対応する CVE / Dependabot アラート ID の明示リスト
-  - Issue へのリンク（判定基準は「PR マージ後に Dependabot の open アラートが 0 件になるか」の 1 点のみ。Issue 本文の記載件数は判定に使わない）:
-    - マージ後に Dependabot の open アラートが 0 件になる場合: `Fixes #<issue-number>`（マージ時に Issue が自動クローズされる）
-    - マージ後も Dependabot の open アラートが残る場合: `Related #<issue-number>`（Issue はオープンのまま残す）
-    - いずれの場合も、Issue 本文未記載の Dependabot アラートを追加で修正している場合は、該当アラートが Issue 本文未記載である旨を PR body に明記する
+  - Issue へのリンク（判定基準は「PR マージ後に Dependabot の修正可能な open アラート（`first_patched_version != null`）が 0 件になるか」の 1 点のみ。security-alert-notify ワークフローが Issue 化対象としているのが修正可能アラートのみのため基準を揃える。Issue 本文の記載件数は判定に使わない）:
+    - マージ後に修正可能な open アラートが 0 件になる場合: `Fixes #<issue-number>`（マージ時に Issue が自動クローズされる）
+    - マージ後も修正可能な open アラートが残る場合: `Related #<issue-number>`（Issue はオープンのまま残す）
+    - いずれの場合も、Issue 本文・コメント未記載の Dependabot アラートを追加で修正している場合は、該当アラートが Issue 未記載である旨を PR body に明記する


### PR DESCRIPTION
## Summary

PR #245 で Issue #242 が自動クローズされなかった問題への再発防止。判定基準を一意化し、Issue 本文の記載件数に引きずられないルールに変更する。

## 背景

PR #245 は Dependabot の open アラート 5 件すべて（Issue 本文記載の 2 件 + 本文未記載の 3 件）を修正したが、PR body で `Related #242` を使用したため Issue が自動クローズされず、手動クローズが必要になった。

既存 skill の 3 つの条件（「全アラート修正なら Fixes」「一部なら Related」「body 未記載アラート修正なら Related」）が相互に衝突しており、今回のように「全 Dependabot アラート修正 + body 未記載分あり」というケースで判断がブレた。

## 変更内容

`.claude/skills/security-fix/SKILL.md` の PR body 規約を次のように改訂:

- **判定基準を 1 点に統一**: 「PR マージ後に Dependabot の open アラートが 0 件になるか」。Issue 本文の記載件数は判定に使わない。
- **Body 未記載アラートの注記**: 独立した要件として残す（`Fixes`/`Related` どちらの場合でも適用される）。

これにより「全アラート修正 + body 未記載分あり」のケースは `Fixes` に一意に決まる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)