### PR TITLE
chore(serena): 新しい設定オプションを追加

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -134,3 +134,17 @@ line_ending:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}


### PR DESCRIPTION
## Summary
- serena更新で追加された `ignored_memory_patterns` と `ls_specific_settings` のデフォルト値を `.serena/project.yml` に追記
- いずれも空の初期値（既存挙動に影響なし）

## Test plan
- [x] `.serena/project.yml` の差分が追加のみであることを確認
- [ ] serena起動時にエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)