### PR TITLE
fix(security): CVE-2026-54466 の脆弱性を修正

### DIFF
--- a/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package-lock.json
+++ b/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package-lock.json
@@ -4265,9 +4265,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package.json
+++ b/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package.json
@@ -29,6 +29,7 @@
     "picomatch@2": "~2.3.2",
     "node-forge@1": "~1.4.0",
     "follow-redirects@1": "~1.16.0",
-    "uuid@8": "~14.0.0"
+    "uuid@8": "~14.0.0",
+    "websocket-driver@0": "~0.7.5"
   }
 }


### PR DESCRIPTION
## 概要

Dependabot が検出した websocket-driver の脆弱性を修正します。

## 対応する CVE / Dependabot アラート

| CVE | アラート | パッケージ | 深刻度 | 影響バージョン | 修正版 |
|---|---|---|---|---|---|
| CVE-2026-54466 | #725 | websocket-driver | critical | < 0.7.5 | 0.7.5 |

- 対象: `Terraform/AWS/Resources/APIGateway/synthetics_test_api/package-lock.json`

## 修正内容

- websocket-driver は webpack-dev-server → sockjs 経由の間接依存（devDependencies）のため、package.json の `overrides` に `"websocket-driver@0": "~0.7.5"` を追加
- `npm install` により package-lock.json の websocket-driver を 0.7.4 → 0.7.5 に更新

## 検証

- `npm ls websocket-driver` で全経路が 0.7.5 に解決されることを確認
- `npm audit` で CVE-2026-54466（websocket-driver）が解消されたことを確認
- `git diff` の変更が websocket-driver の更新と overrides 追加のみであることを確認
- 更新版の安全性確認: `npm view websocket-driver@0.7.5 dist` で provenance は未付与だが、WebSearch で直近のサプライチェーン compromise 報告がないことを確認済み

本 PR のマージにより、修正可能な open Dependabot アラートは 0 件になります。

Fixes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)