### PR TITLE
fix(security): CVE-2026-48779 (ws) の脆弱性を修正

### DIFF
--- a/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package-lock.json
+++ b/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package-lock.json
@@ -4313,9 +4313,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package.json
+++ b/Terraform/AWS/Resources/APIGateway/synthetics_test_api/package.json
@@ -30,6 +30,7 @@
     "node-forge@1": "~1.4.0",
     "follow-redirects@1": "~1.16.0",
     "uuid@8": "~14.0.0",
-    "websocket-driver@0": "~0.7.5"
+    "websocket-driver@0": "~0.7.5",
+    "ws@8": "~8.21.0"
   }
 }


### PR DESCRIPTION
## 概要

Dependabot が検出した ws パッケージの脆弱性を修正します。

## 対応する CVE / Dependabot アラート

| アラート | CVE | パッケージ | 深刻度 | 影響範囲 | 修正版 |
|---|---|---|---|---|---|
| [#703](https://github.com/yuki-m1216/Training/security/dependabot/703) | CVE-2026-48779 | ws | high | >= 8.0.0, < 8.21.0 | 8.21.0 |

- 対象: `Terraform/AWS/Resources/APIGateway/synthetics_test_api/package-lock.json`

## 変更内容

- `ws` は `webpack-dev-server@5.2.5` 経由の間接依存のため、`package.json` の `overrides` に `"ws@8": "~8.21.0"` を追加
- `package-lock.json` を更新（`ws` 8.18.0 → 8.21.1）

## 検証

- `npm ls ws` で `ws@8.21.1`（修正版 8.21.0 以上）に更新されたことを確認
- `npm audit` で CVE-2026-48779 が解消されたことを確認
- `git diff` で lockfile の差分が ws のエントリのみであることを確認
- install 前に `npm view ws@8.21.0` で公開日（2026-05-22、約2ヶ月前）を確認し、直近のサプライチェーン攻撃情報がないことを確認済み

本 PR のマージにより、修正可能な open Dependabot アラートは 0 件になります。

Fixes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)