### PR TITLE
feat(cdk): AgentCore Runtime を直接コードデプロイで追加

### DIFF
--- a/CDK/agentcore-gateway/.gitignore
+++ b/CDK/agentcore-gateway/.gitignore
@@ -6,3 +6,6 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# AgentCore Runtime 用の生成物(build.sh の出力。再生成可能なので管理しない)
+runtime-code/build/

--- a/CDK/agentcore-gateway/README.md
+++ b/CDK/agentcore-gateway/README.md
@@ -10,11 +10,59 @@ Lambda ツールを1本登録し、X-Ray Transaction Search で観測できる�
 | スタック | 内容 |
 | --- | --- |
 | `FoundationStack` | Cognito ユーザープール / ドメイン / リソースサーバー(`agentcore/read`) / M2M アプリクライアント |
-| `AgentPlatformStack` | AgentCore Gateway(CUSTOM_JWT 認可・exceptionLevel=DEBUG) + Lambda ターゲット(MCP ツール名 `hello___hello_world`) |
+| `AgentPlatformStack` | AgentCore Gateway(CUSTOM_JWT 認可・exceptionLevel=DEBUG) + Lambda ターゲット(MCP ツール名 `hello___hello_world`)、AgentCore Runtime(strands エージェント・直接コードデプロイ・CUSTOM_JWT 認可) |
 | `ObservabilityStack` | X-Ray Transaction Search 有効化(アカウント×リージョンレベル設定・他スタック非依存) |
 
 - FoundationStack → AgentPlatformStack はコンストラクト参照を props で渡す(CFN 上は Export/Import)
 - 検証用のため UserPool は `removalPolicy: DESTROY`。本番では RETAIN + deletionProtection が定石
+
+## AgentCore Runtime (runtime-code/)
+
+`runtime-code/` は Runtime にデプロイするエージェント本体(strands + Haiku 4.5)。
+Docker/ECR を使わない直接コードデプロイ(`AgentRuntimeArtifact.fromCodeAsset`)のため、
+依存は Runtime の実行基盤(linux/arm64, Python 3.13)向けにバンドルする必要がある。
+
+```bash
+# synth / test / deploy の前に必ず実行(build/ は gitignore 対象の生成物)
+./runtime-code/build.sh
+```
+
+呼び出しは JWT 認証のため boto3/CLI 不可。HTTPS 直接:
+`POST https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{URLエンコードしたRuntimeArn}/invocations?qualifier=DEFAULT`
+に `Authorization: Bearer`(Gateway と同じ Cognito トークン) +
+`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`(33文字以上) + `{"prompt": "..."}`。
+
+注意: Bedrock モデルの初回利用はアカウントで Marketplace 契約(agreement)の締結が必要。
+未締結だと Runtime 内の ConverseStream が AccessDeniedException(aws-marketplace:Subscribe
+の文言)で落ちる。管理者がプレイグラウンドで一度モデルを実行するか
+`create-foundation-model-agreement` で締結してから検証する。
+
+## 現在の構成と次のステップ(Runtime → Gateway 接続)
+
+現状、Runtime と Gateway は Foundation の Cognito を共有するだけの並列構成で、
+Runtime のエージェントはツールを持たない(Haiku が素で応答するだけ)。
+
+```
+[クライアント] ─Bearer─→ Runtime (strands + Haiku)        ← ツールなし
+[クライアント] ─Bearer─→ Gateway ─→ Lambda (hello_world)
+```
+
+次のフィーチャーブランチで、AgentCore のリファレンス構成
+「Runtime のエージェントが Gateway を MCP サーバーとして利用する」形に進める:
+
+```
+[クライアント] ─Bearer─→ Runtime (strands)
+                            │ MCP + Bearer (アウトバウンド認可)
+                            ▼
+                         Gateway ─→ Lambda ツール群
+```
+
+予定している変更:
+
+1. agent.py に strands の MCP クライアントを追加し、`GatewayUrl` のツール群を `Agent(tools=...)` に渡す
+2. アウトバウンド認可は **AgentCore Identity の OAuth クレデンシャルプロバイダー**を使う
+   (Runtime の環境変数にクライアントシークレットを直接置く簡易案は採らない)
+3. Gateway URL は Runtime の `environmentVariables` でスタック内配線
 
 ## 前提
 

--- a/CDK/agentcore-gateway/lib/agent-platform-stack.ts
+++ b/CDK/agentcore-gateway/lib/agent-platform-stack.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
@@ -98,8 +99,16 @@ def handler(event, context):
     // 直接コードデプロイ: Docker/ECR を使わず、build.sh の出力(arm64 依存 + agent.py)を
     // zip 化して CDK 管理の S3 バケットへアップロードする方式。
     // build/ は生成物のため、synth 前に runtime-code/build.sh の実行が前提
+    const runtimeCodePath = path.join(__dirname, '..', 'runtime-code', 'build');
+    // build.sh の実行漏れをライブラリ内部の一般的な ENOENT ではなく、
+    // 復旧手順が分かるメッセージで synth 時点に fail-fast させる
+    if (!fs.existsSync(path.join(runtimeCodePath, 'agent.py'))) {
+      throw new Error(
+        'runtime-code/build/ が未生成です。先に CDK/agentcore-gateway/runtime-code/build.sh を実行してください(依存を arm64 向けにバンドルして build/ を生成します)',
+      );
+    }
     const artifact = agentcore.AgentRuntimeArtifact.fromCodeAsset({
-      path: path.join(__dirname, '..', 'runtime-code', 'build'),
+      path: runtimeCodePath,
       // AWS がマネージドで用意する実行環境のバージョン。build.sh の
       // --python-version 3.13 とペアで、ズレると import エラーになる
       runtime: agentcore.AgentCoreRuntime.PYTHON_3_13,

--- a/CDK/agentcore-gateway/lib/agent-platform-stack.ts
+++ b/CDK/agentcore-gateway/lib/agent-platform-stack.ts
@@ -1,6 +1,8 @@
+import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 
@@ -90,5 +92,48 @@ def handler(event, context):
       );
     }
     new cdk.CfnOutput(this, 'GatewayUrl', { value: gateway.gatewayUrl });
+
+    // ---- AgentCore Runtime (strands エージェント本体) ----
+
+    // 直接コードデプロイ: Docker/ECR を使わず、build.sh の出力(arm64 依存 + agent.py)を
+    // zip 化して CDK 管理の S3 バケットへアップロードする方式。
+    // build/ は生成物のため、synth 前に runtime-code/build.sh の実行が前提
+    const artifact = agentcore.AgentRuntimeArtifact.fromCodeAsset({
+      path: path.join(__dirname, '..', 'runtime-code', 'build'),
+      // AWS がマネージドで用意する実行環境のバージョン。build.sh の
+      // --python-version 3.13 とペアで、ズレると import エラーになる
+      runtime: agentcore.AgentCoreRuntime.PYTHON_3_13,
+      // zip ルートの agent.py を起動する(Dockerfile の CMD 相当)
+      entrypoint: ['agent.py'],
+    });
+
+    const runtime = new agentcore.Runtime(this, 'AgentRuntime', {
+      // Runtime 名はハイフン不可(^[a-zA-Z][a-zA-Z0-9_]{0,47}$)のためスネークケース
+      runtimeName: 'training_agent',
+      agentRuntimeArtifact: artifact,
+      // Gateway と同じ Foundation の Cognito を信頼元にする。
+      // Gateway の usingCognito({...}) と違い Runtime 側は位置引数 + クライアント配列。
+      // JWT を設定すると SigV4(IAM) では呼べなくなる(併用不可)点に注意
+      authorizerConfiguration: agentcore.RuntimeAuthorizerConfiguration.usingCognito(
+        props.userPool,
+        [props.userPoolClient],
+      ),
+    });
+
+    // 自動生成される実行ロールには ECR/CloudWatch 系しか無いため、strands が
+    // Bedrock のモデルを呼ぶための権限を明示付与する。宛先は jp. 推論プロファイルと、
+    // そこからルーティングされ得る国内リージョンの Haiku 4.5 基盤モデルに限定
+    runtime.role.addToPrincipalPolicy(new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+      resources: [
+        `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/jp.anthropic.claude-haiku-4-5-*`,
+        // 基盤モデル ARN はアカウント ID を持たず、ルーティング先リージョンが
+        // プロファイル側の都合で変わり得るためリージョンはワイルドカード
+        'arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-*',
+      ],
+    }));
+
+    // invoke 検証(Bearer トークンで直接 HTTPS)の URL 組み立てに ARN が必要になる
+    new cdk.CfnOutput(this, 'RuntimeArn', { value: runtime.agentRuntimeArn });
   }
 }

--- a/CDK/agentcore-gateway/runtime-code/agent.py
+++ b/CDK/agentcore-gateway/runtime-code/agent.py
@@ -1,0 +1,33 @@
+from bedrock_agentcore import BedrockAgentCoreApp
+from strands import Agent
+from strands.models import BedrockModel
+
+# /invocations (POST) と /ping (GET) を 8080 番で提供する HTTP サーバーの実体。
+# AgentCore Runtime のサービスコントラクトはこの SDK が担うため、自前実装は不要
+app = BedrockAgentCoreApp()
+
+# strands のデフォルトモデルは US リージョン向けプロファイルのため、東京では
+# ValidationException になる。jp. プレフィックス(国内クロスリージョン推論)を明示する
+model = BedrockModel(
+    model_id="jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+    region_name="ap-northeast-1",
+)
+agent = Agent(model=model)
+
+
+# Runtime が /invocations で受けたリクエストボディ(JSON)が payload に渡ってくる
+@app.entrypoint
+def invoke(payload):
+    # ペイロード形式はエージェント実装の自由だが、公式サンプルの慣例に合わせて
+    # {"prompt": "..."} を受ける。キー欠落時は挙動確認しやすい固定文にフォールバック
+    prompt = payload.get("prompt", "こんにちは。自己紹介してください")
+    result = agent(prompt)
+    # AgentResult.message は {role, content} の dict で JSON 直列化可能。
+    # テキストだけ返すと途中経過が失われるため message ごと返す
+    return {"result": result.message}
+
+
+# entrypoint 指定で `python agent.py` として実行された時のみサーバーを起動する。
+# (将来テスト等で import された場合に起動してしまうのを防ぐ)
+if __name__ == "__main__":
+    app.run()

--- a/CDK/agentcore-gateway/runtime-code/build.sh
+++ b/CDK/agentcore-gateway/runtime-code/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# AgentCore Runtime 直接コードデプロイ用の依存バンドルを build/ に生成する。
+# Runtime の実行基盤は linux/arm64 + Python 3.13 のため、手元の環境(x86)ではなく
+# ターゲット向けの wheel を取得する必要がある(取り違えるとデプロイ後に import エラー)。
+set -euo pipefail
+
+# スクリプトの置き場所を基準に動く(どのディレクトリから叩いても同じ結果にする)
+cd "$(dirname "$0")"
+
+# 前回の残骸(削除済み依存など)が混入しないよう毎回作り直す
+rm -rf build
+mkdir build
+
+# --python-platform/--python-version: Runtime(linux/arm64, Python 3.13)向けの wheel を指定
+# --only-binary=:all:  : arm64 wheel が無いパッケージはソースビルドせずエラーにする
+#                        (黙って x86 バイナリが混入するのが最悪パターンのため)
+uv pip install \
+  --python-platform aarch64-manylinux2014 \
+  --python-version 3.13 \
+  --only-binary=:all: \
+  --target build \
+  -r requirements.txt
+
+# エントリポイントは zip のルートに置く必要がある(CDK は build/ ごと zip 化する)
+cp agent.py build/
+
+# x86 でコンパイルされたバイトコードの混入防止(公式の明記事項)
+find build -type d -name '__pycache__' -exec rm -rf {} +
+
+# POSIX 権限の正規化: ディレクトリ 755 / ファイル 644 (公式の要求)
+find build -type d -exec chmod 755 {} +
+find build -type f -exec chmod 644 {} +
+
+echo "OK: $(du -sh build | cut -f1) bundled into runtime-code/build/"

--- a/CDK/agentcore-gateway/runtime-code/requirements.txt
+++ b/CDK/agentcore-gateway/runtime-code/requirements.txt
@@ -1,0 +1,4 @@
+# AgentCore Runtime のサービスコントラクト(/invocations, /ping)を提供する SDK
+bedrock-agentcore==1.19.0
+# エージェントフレームワーク本体(Bedrock Converse API 経由で LLM を呼ぶ)
+strands-agents==1.50.2

--- a/CDK/agentcore-gateway/test/agent-platform-stack.test.ts
+++ b/CDK/agentcore-gateway/test/agent-platform-stack.test.ts
@@ -85,4 +85,57 @@ describe('AgentPlatformStack', () => {
   test('MCP エンドポイント URL が出力されている (要件5)', () => {
     template.hasOutput('GatewayUrl', {});
   });
+
+  /**
+   * AgentCore Runtime の期待仕様(直接コードデプロイ + Cognito JWT 認可)
+   *
+   * 注意: fromCodeAsset は synth 時に runtime-code/build/ (build.sh の出力)を
+   * S3 アセットとしてステージングするため、テスト実行前に build.sh の実行が必要。
+   */
+  test('Runtime は1つ。直接コードデプロイ(S3 + PYTHON_3_13 + agent.py) (要件6)', () => {
+    template.resourceCountIs('AWS::BedrockAgentCore::Runtime', 1);
+    template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', Match.objectLike({
+      AgentRuntimeArtifact: Match.objectLike({
+        // コンテナ方式なら ContainerConfiguration になる。CodeConfiguration である
+        // こと自体が「Docker/ECR 不要の直接コードデプロイ」という仕様の表明
+        CodeConfiguration: Match.objectLike({
+          // バケット名/プレフィックスは CDK が採番するアセットハッシュのため形だけ検証
+          Code: Match.objectLike({ S3: Match.anyValue() }),
+          Runtime: 'PYTHON_3_13',
+          // zip ルートの agent.py が起動される(Dockerfile の CMD に相当)
+          EntryPoint: ['agent.py'],
+        }),
+      }),
+    }));
+  });
+
+  test('Runtime のインバウンド認可は Gateway と同じ Cognito(CUSTOM_JWT) (要件7)', () => {
+    template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', Match.objectLike({
+      AuthorizerConfiguration: Match.objectLike({
+        // Gateway と同様、usingCognito は CustomJWTAuthorizer に変換される。
+        // 同じ Foundation のプール/クライアントを信頼元にするのが仕様
+        CustomJWTAuthorizer: Match.objectLike({
+          DiscoveryUrl: Match.anyValue(),
+          AllowedClients: [Match.anyValue()],
+        }),
+      }),
+    }));
+  });
+
+  test('Runtime 実行ロールに Bedrock モデル呼び出し権限がある (要件8)', () => {
+    // strands が Bedrock Converse API (InvokeModel系)で Haiku を呼ぶために必要。
+    // Runtime コンストラクトの自動生成ロールには含まれないので明示付与が仕様
+    template.hasResourceProperties('AWS::IAM::Policy', Match.objectLike({
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith([
+              'bedrock:InvokeModel',
+              'bedrock:InvokeModelWithResponseStream',
+            ]),
+          }),
+        ]),
+      }),
+    }));
+  });
 });

--- a/CDK/agentcore-gateway/test/agent-platform-stack.test.ts
+++ b/CDK/agentcore-gateway/test/agent-platform-stack.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { FoundationStack } from '../lib/foundation-stack';
@@ -14,7 +16,22 @@ import { AgentPlatformStack } from '../lib/agent-platform-stack';
 describe('AgentPlatformStack', () => {
   let template: Template;
 
+  // fromCodeAsset が参照する build/ は build.sh の生成物のため、CI や初回 checkout の
+  // クリーン環境には存在しない。synth に必要なのはディレクトリと agent.py だけなので、
+  // 無ければ最小ダミーを作って npm test を単体で再現可能にする
+  const buildDir = path.join(__dirname, '..', 'runtime-code', 'build');
+  let buildDirCreatedByTest = false;
+
   beforeAll(() => {
+    if (!fs.existsSync(path.join(buildDir, 'agent.py'))) {
+      fs.mkdirSync(buildDir, { recursive: true });
+      fs.copyFileSync(
+        path.join(buildDir, '..', 'agent.py'),
+        path.join(buildDir, 'agent.py'),
+      );
+      buildDirCreatedByTest = true;
+    }
+
     const app = new cdk.App();
     const env = { account: '111111111111', region: 'ap-northeast-1' };
     const foundation = new FoundationStack(app, 'TestFoundationStack', { env });
@@ -24,6 +41,14 @@ describe('AgentPlatformStack', () => {
       userPoolClient: foundation.userPoolClient,
     });
     template = Template.fromStack(stack);
+  });
+
+  afterAll(() => {
+    // テストが作ったダミー build/ は残さない。依存を含まない偽バンドルが
+    // そのまま cdk deploy に使われる事故を防ぐ(開発者が build.sh で作った本物は触らない)
+    if (buildDirCreatedByTest) {
+      fs.rmSync(buildDir, { recursive: true, force: true });
+    }
   });
 
   test('Gateway は1つ。インバウンド認可は CUSTOM_JWT(usingCognito の変換結果) (要件2)', () => {
@@ -124,7 +149,9 @@ describe('AgentPlatformStack', () => {
 
   test('Runtime 実行ロールに Bedrock モデル呼び出し権限がある (要件8)', () => {
     // strands が Bedrock Converse API (InvokeModel系)で Haiku を呼ぶために必要。
-    // Runtime コンストラクトの自動生成ロールには含まれないので明示付与が仕様
+    // Runtime コンストラクトの自動生成ロールには含まれないので明示付与が仕様。
+    // Action だけでなく Resource も検証し、誤って '*' に広がったら検知する
+    // (jp. 推論プロファイル + ルーティング先の Haiku 4.5 基盤モデルに限定するのが仕様)
     template.hasResourceProperties('AWS::IAM::Policy', Match.objectLike({
       PolicyDocument: Match.objectLike({
         Statement: Match.arrayWith([
@@ -132,6 +159,10 @@ describe('AgentPlatformStack', () => {
             Action: Match.arrayWith([
               'bedrock:InvokeModel',
               'bedrock:InvokeModelWithResponseStream',
+            ]),
+            Resource: Match.arrayWith([
+              'arn:aws:bedrock:ap-northeast-1:111111111111:inference-profile/jp.anthropic.claude-haiku-4-5-*',
+              'arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-*',
             ]),
           }),
         ]),


### PR DESCRIPTION
## 概要

AgentPlatformStack に AgentCore Runtime を追加。Docker/ECR を使わない直接コードデプロイ(`AgentRuntimeArtifact.fromCodeAsset`)で strands エージェント(Haiku 4.5)を動かし、Gateway と同じ Foundation の Cognito(CUSTOM_JWT)で保護する。

## 変更内容

- **runtime-code/**: エージェント本体
  - `agent.py`: BedrockAgentCoreApp + strands Agent(`jp.anthropic.claude-haiku-4-5` 国内クロスリージョンプロファイル)
  - `build.sh`: linux/arm64 + Python 3.13 向け依存バンドル(uv, `--only-binary=:all:` でフェイルファースト)。出力 `build/` は gitignore
- **lib/agent-platform-stack.ts**: Runtime 追加(TDD: Red→Green)
  - `fromCodeAsset`(PYTHON_3_13, entrypoint `agent.py`)
  - `RuntimeAuthorizerConfiguration.usingCognito(userPool, [userPoolClient])`
  - 実行ロールへ `bedrock:InvokeModel(+WithResponseStream)` を jp. プロファイル + Haiku 4.5 基盤モデルに限定して付与
  - invoke 用に `RuntimeArn` を出力
- **test/agent-platform-stack.test.ts**: Runtime の期待仕様3件を追加(計18テスト Green)
- **README.md**: Runtime の使い方(build.sh 前提・JWT での HTTPS 直接 invoke・Marketplace 契約の注意)と次ステップ(Runtime→Gateway MCP 接続 + AgentCore Identity)を記載

## 検証

- `npm test`: 3スイート18テスト Green
- デプロイ後の E2E(ap-northeast-1):
  - 認証ヘッダーなし → 401(JWT オーソライザーが拒否)
  - Cognito client_credentials トークン → 200、Haiku の応答と usage/latency を確認
  - **Gateway と同一トークン**で MCP tools/list も 200(認証基盤共有の確認)

## 補足

検証中に Bedrock モデル初回利用の Marketplace 契約未締結による `AccessDeniedException` を踏んだ(README に注意書きとして記録)。管理者がプレイグラウンドで一度実行し契約締結後は解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)